### PR TITLE
find Pool ID regardless of number of subscriptions.

### DIFF
--- a/packstack/plugins/prescript_000.py
+++ b/packstack/plugins/prescript_000.py
@@ -1073,8 +1073,8 @@ def run_rhsm_reg(host, username, password, optional=False, proxy_server=None,
         cmd = ('subscription-manager list --consumed | grep -i openstack || '
                'subscription-manager subscribe --pool %s')
         pool = ("$(subscription-manager list --available"
-                " | grep -m1 -A15 'Red Hat Enterprise Linux OpenStack Platform'"
-                " | grep -i 'Pool ID:' | awk '{print $3}')")
+                " | sed -n \'/Red Hat Enterprise Linux OpenStack Platform/,/Pool ID:/ { s/Pool ID:[[:space:]]*\\([[:alnum:]]*\\)/\\1/ p} \'"
+                " | head -1 )")
         server.append(cmd % pool)
 
     if optional:


### PR DESCRIPTION
Packstack fails to find OSP Pool ID because shell scripting doesn't account for long subscription "Provides" lists.

This fixes that.

Also reported in LaunchPad: https://bugs.launchpad.net/packstack/+bug/1551424

Errant original code: https://github.com/openstack/packstack/blob/4ea165cafd8be903c87a2ac34dc0237d3a56e8bc/packstack/plugins/prescript_000.py#L1076

The above line fails because my subscription has a lot of available products:

 root  ~  subscription-manager list --available | grep -m1 -A15 'Red Hat Enterprise Linux OpenStack Platform'
Subscription Name: Red Hat Enterprise Linux OpenStack Platform Standard Supported Business Partner NFR
Provides: Red Hat OpenStack Beta
                     Red Hat OpenStack Beta Certification Test Suite
                     Red Hat Software Collections (for RHEL Server)
                     Red Hat Ceph Storage Calamari
                     Red Hat Enterprise MRG Messaging
                     Red Hat OpenStack Certification Test Suite
                     Red Hat Beta
                     Red Hat Ceph Storage MON
                     Red Hat Ceph Storage
                     Red Hat OpenStack
                     Red Hat Enterprise Linux for Real Time
                     Red Hat Enterprise Linux High Availability (for RHEL Server)
                     Red Hat Enterprise Linux Server
                     Red Hat Software Collections Beta (for RHEL Server)
                     Red Hat Enterprise Linux Load Balancer (for RHEL Server)
[Errno 32] Broken pipe