### PR TITLE
Fixed issue with wrong value of scheduler host manager for Newton release

### DIFF
--- a/Puppetfile.ironic
+++ b/Puppetfile.ironic
@@ -1,0 +1,158 @@
+moduledir '/usr/share/openstack-puppet/modules'
+
+## OpenStack modules
+
+mod 'aodh',
+  :git => 'https://github.com/openstack/puppet-aodh',
+  :ref => 'stable/newton'
+
+mod 'ceilometer',
+  :git => 'https://github.com/openstack/puppet-ceilometer',
+  :ref => 'stable/newton'
+
+mod 'cinder',
+  :git => 'https://github.com/openstack/puppet-cinder',
+  :ref => 'stable/newton'
+
+mod 'glance',
+  :git => 'https://github.com/openstack/puppet-glance',
+  :ref => 'stable/newton'
+
+mod 'gnocchi',
+  :git => 'https://github.com/openstack/puppet-gnocchi',
+  :ref => 'stable/newton'
+
+mod 'heat',
+  :git => 'https://github.com/openstack/puppet-heat',
+  :ref => 'stable/newton'
+
+mod 'horizon',
+  :git => 'https://github.com/openstack/puppet-horizon',
+  :ref => 'stable/newton'
+
+mod 'ironic',
+  :git => 'https://github.com/openstack/puppet-ironic',
+  :ref => 'stable/newton'
+
+mod 'keystone',
+  :git => 'https://github.com/openstack/puppet-keystone',
+  :ref => 'stable/newton'
+
+mod 'manila',
+  :git => 'https://github.com/openstack/puppet-manila',
+  :ref => 'stable/newton'
+
+mod 'neutron',
+  :git => 'https://github.com/openstack/puppet-neutron',
+  :ref => 'stable/newton'
+
+mod 'nova',
+  :git => 'https://github.com/jodlajodla/puppet-nova',
+  :ref => 'stable/newton'
+
+mod 'openstack_extras',
+  :git => 'https://github.com/openstack/puppet-openstack_extras',
+  :ref => 'stable/newton'
+
+mod 'openstacklib',
+  :git => 'https://github.com/openstack/puppet-openstacklib',
+  :ref => 'stable/newton'
+
+mod 'oslo',
+  :git => 'https://github.com/openstack/puppet-oslo',
+  :ref => 'stable/newton'
+
+mod 'sahara',
+  :git => 'https://github.com/openstack/puppet-sahara',
+  :ref => 'stable/newton'
+
+mod 'swift',
+  :git => 'https://github.com/openstack/puppet-swift',
+  :ref => 'stable/newton'
+
+mod 'tempest',
+  :git => 'https://github.com/openstack/puppet-tempest',
+  :ref => 'stable/newton'
+
+mod 'trove',
+  :git => 'https://github.com/openstack/puppet-trove',
+  :ref => 'stable/newton'
+
+mod 'vswitch',
+  :git => 'https://github.com/openstack/puppet-vswitch',
+  :ref => 'stable/newton'
+
+## Non-OpenStack modules
+
+mod 'apache',
+  :git => 'https://github.com/puppetlabs/puppetlabs-apache',
+  :ref => 'master'
+
+mod 'certmonger',
+  :git => 'https://github.com/rcritten/puppet-certmonger',
+  :ref => 'master'
+
+mod 'concat',
+  :git => 'https://github.com/puppetlabs/puppetlabs-concat',
+  :ref => 'master'
+
+mod 'firewall',
+  :git => 'https://github.com/puppetlabs/puppetlabs-firewall',
+  :ref => 'master'
+
+mod 'inifile',
+  :git => 'https://github.com/puppetlabs/puppetlabs-inifile',
+  :ref => 'master'
+
+mod 'memcached',
+  :git => 'https://github.com/saz/puppet-memcached',
+  :ref => 'master'
+
+mod 'mongodb',
+  :git => 'https://github.com/puppetlabs/puppetlabs-mongodb',
+  :ref => 'master'
+
+mod 'mysql',
+  :git => 'https://github.com/puppetlabs/puppetlabs-mysql',
+  :ref => 'master'
+
+mod 'nssdb',
+  :git => 'https://github.com/rcritten/puppet-nssdb',
+  :ref => 'master'
+
+mod 'rabbitmq',
+  :git => 'https://github.com/puppetlabs/puppetlabs-rabbitmq',
+  :ref => 'master'
+
+mod 'redis',
+  :git => 'https://github.com/arioch/puppet-redis',
+  :ref => 'master'
+
+mod 'remote',
+  :git => 'https://github.com/paramite/puppet-remote',
+  :ref => 'master'
+
+mod 'rsync',
+  :git => 'https://github.com/puppetlabs/puppetlabs-rsync',
+  :ref => 'master'
+
+mod 'ssh',
+  :git => 'https://github.com/saz/puppet-ssh',
+  :ref => 'master'
+
+mod 'stdlib',
+  :git => 'https://github.com/puppetlabs/puppetlabs-stdlib',
+  :ref => 'master'
+
+mod 'sysctl',
+  :git => 'https://github.com/duritong/puppet-sysctl',
+  :ref => 'master'
+
+mod 'vcsrepo',
+  :git => 'https://github.com/puppetlabs/puppetlabs-vcsrepo',
+  :ref => 'master'
+
+mod 'xinetd',
+  :git => 'https://github.com/puppetlabs/puppetlabs-xinetd',
+  :ref => 'master'
+

--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ can be performed only by running a script, without any additional effort.
 
     $ yum install -y git
     $ git clone git://github.com/jodlajodla/packstack.git
-    $ cd packstack && sudo bash run_setup.sh ironic
+    $ cd packstack && git checkout stable/newton
+    $ sudo bash run_setup.sh ironic
 
 ## Installation of Packstack with default components:
 
     $ yum install -y git
     $ git clone git://github.com/jodlajodla/packstack.git
-    $ cd packstack && sudo bash run_setup.sh
+    $ cd packstack && git checkout stable/newton
+    $ sudo bash run_setup.sh
 
 ## Development and general information
 

--- a/README.md
+++ b/README.md
@@ -1,229 +1,37 @@
 # Packstack
 
-Utility to install **OpenStack** on **Red Hat** based operating system. See
-other branches for older **OpenStack** versions. Details on how to
-contribute to **Packstack** may be found in the **Packstack** wiki at
-<https://wiki.openstack.org/wiki/Packstack> Additional information
-about involvement in the community around **Packstack** can be found at
-<https://openstack.redhat.com/Get_involved>
+Fork of official Packstack repo which contains fix for installing Packstack
+with Ironic on CentOS 7 with OpenStack Newton release. There is only one
+changed file `packstack/puppet/modules/packstack/manifests/nova/sched/ironic.pp`
+which contains fix for correct value of `scheduler_host_manager` for Newton
+release.
 
+This repository also contains installation script `run_setup.sh`, so the installation
+can be performed only by running a script, without any additional effort.
 
-This utility can be used to install **OpenStack** on a single or group of
-hosts (over `ssh`).
-
-This utility is still in the early stages, a lot of the configuration
-options have yet to be added.
-
-## Installation of packstack:
+## Installation of Packstack with Ironic:
 
     $ yum install -y git
-    $ git clone git://github.com/openstack/packstack.git
-    $ cd packstack && sudo python setup.py install
+    $ git clone git://github.com/jodlajodla/packstack.git
+    $ cd packstack && sudo bash run_setup.sh ironic
 
-## Installation of openstack-puppet-modules (REQUIRED if running packstack from source):
+## Installation of Packstack with default components:
 
-    $ export GEM_HOME=/tmp/somedir
-    $ gem install r10k
-    $ sudo /tmp/somedir/bin/r10k puppetfile install -v
-    $ sudo cp -r packstack/puppet/modules/packstack /usr/share/openstack-puppet/modules
+    $ yum install -y git
+    $ git clone git://github.com/jodlajodla/packstack.git
+    $ cd packstack && sudo bash run_setup.sh
 
-### Option 1 (all-in-one)
+## Development and general information
 
-    $ packstack --allinone
+For any additional information about development or anything other connected to
+Packstack, please refer to original README (in file `README_ORIGINAL`),
+or check official repository located at https://github.com/openstack/packstack
 
-This will install all **OpenStack** services on a single host without
-prompting for any configuration information.  This will generate an
-"answers" file (`packstack-answers-<date>-<time>.txt`) containing all
-the values used for the install.
+## License
 
-If you need to re-run packstack, you must use the `--answer-file`
-option in order for packstack to use the correct values for passwords
-and other authentication credentials:
-
-    $ packstack --answer-file packstack-answers-<date>-<time>.txt
-
-### Option 2 (using answer file)
-
-    $ packstack --gen-answer-file=ans.txt
-
-Then edit `ans.txt` as appropriate e.g.
-
-- set `CONFIG_SSH_KEY` to a public ssh key to be installed to remote machines
-- Edit the IP address to anywhere you want to install a piece of OpenStack on another server
-- Edit the 3 network interfaces to whatever makes sense in your setup
-
-you'll need to use a icehouse repository for example for RHEL
-
-    $ CONFIG_REPO=http://repos.fedorapeople.org/repos/openstack/openstack-icehouse/epel-6/
-
-    $ packstack --answer-file=ans.txt
-
-### Option 3 (prompts for configuration options)
-
-    $ packstack
-
-that's it, if everything went well you can now start using OpenStack
-
-    $ cd
-    $ . keystonerc_admin
-    $ nova list
-    $ swift list  # if you have installed swift
-
-## Config options
-
-- `CONFIG_NOVA_COMPUTE_HOSTS` :
-  * A comma separated list of ip addresses on which to install nova compute
-- `CONFIG_SWIFT_STORAGE_HOSTS` :
-  * A comma separated list of swift storage devices
-    * `1.1.1.1`: create a testing loopback device and use this for storage
-    * `1.1.1.1/sdb`: use `/dev/sdb` on `1.1.1.1` as a storage device
-
-## Logging
-
-The location of the log files and generated puppet manifests are in the
-`/var/tmp/packstack` directory under a directory named by the date in which
-**Packstack** was run and a random string (e.g. `/var/tmp/packstack/20131022-204316-Bf3Ek2`).
-Inside, we find a manifest directory and the `openstack-setup.log` file; puppet
-manifests and a log file for each one are found inside the manifest directory.
-
-## Debugging
-
-To make **Packstack** write more detailed information into the log file you can use the `-d` switch:
-
-    $ packstack -d --allinone
-
-## Developing
-
-**Warning:**
-this procedure installs **openstack-puppet-modules** containing code that has
-not been upstreamed and fully tested yet and as such will not be as robust as
-the other install procedures.  It is recommended to install from **RPM**
-instead.
-
-To ease development of **Packstack** and **openstack-puppet-modules**, it can be
-useful to install from *git* such that updates to the git repositories are
-immediately effective without reinstallation of packstack and
-**openstack-puppet-modules**.
-
-To do this, start with a minimal **Fedora 21** installation.  Then remove any
-relevant packages that might conflict:
-
-    $ yum -y erase openstack-{packstack*,puppet-modules}
-
-Disable **SELinux** by changing "`enforcing`" to "`permissive`" in
-`/etc/sysconfig/selinux`, then reboot to allow service changes to take effect
-and swap over networking.  Then install packages:
-
-    $ yum -y install git python-setuptools
-
-And install **RDO**:
-
-    $ yum -y install https://rdo.fedorapeople.org/rdo-release.rpm
-    $ yum -y update
-
-Now we get **openstack-puppet-modules**.  Because `python setup.py
-install_puppet_modules` from **Packstack** copies rather than linking, this is not
-entirely straightforward:
-
-    $ git clone https://github.com/redhat-openstack/openstack-puppet-modules
-    $ cd openstack-puppet-modules
-    $ git checkout master-patches
-    $ mkdir /usr/share/openstack-puppet
-    $ ln -sv /root/openstack-puppet-modules /usr/share/openstack-puppet/modules
-
-Then we get **Packstack**, and perform a similar dance:
-
-    $ yum install -y python-crypto python-devel libffi-devel openssl-devel gcc-c++
-    $ git clone https://github.com/openstack/packstack
-    $ cd packstack
-    $ python setup.py develop
-    $ cd /usr/share/openstack-puppet/modules
-    $ ln -sv /root/packstack/packstack/puppet/modules/packstack
-
-And we're done.  Changes to the contents of **Packstack** and
-**openstack-puppet-modules** repositories are picked up by the **Packstack**
-executable without further intervention, and **Packstack** is ready to install.
-
-## Puppet Style Guide
-
-**IMPORTANT** <https://docs.puppetlabs.com/guides/style_guide.html>
-
-Please, respect the Puppet Style Guide as much as possible !
-
-## Running local Puppet-lint tests
-
-It assumes that both `bundler` as well as `rubygems` (and `ruby`) are already
-installed on the system. If not, run this command:
-
-    $ sudo yum install rubygems rubygem-bundler ruby ruby-devel -y
-
-Go into the **Packstack** root directory.
-
-    $ cd packstack/
-
-A `Rakefile` contains all you need to run puppet-lint task automatically over
-all the puppet manifests included in the **Packstack** project.
-
-    $ ls -l packstack/puppet/templates/
-
-and
-
-    $ ls -l packstack/puppet/modules/
-
-The default puppet-lint pattern for `.pp` files is `**/*.pp`. So there is no
-need to go inside those directories to run puppet-lint !
-
-    $ mkdir vendor
-    $ export GEM_HOME=vendor
-    $ bundle install
-    $ bundle exec rake lint
-
-## Packstack integration tests
-
-Packstack is integration tested in the OpenStack gate and provides the means to
-reproduce these tests on your environment if you wish.
-
-This is the current matrix of available tests:
-
-|     -      | scenario001 | scenario002 | scenario003 |
-|:----------:|:-----------:|:-----------:|:------------:
-| keystone   |      X      |      X      |      X      |
-| glance     |    file     |    swift    |     file    |
-| nova       |      X      |      X      |      X      |
-| neutron    |      X      |      X      |      X      |
-| lbaasv2    |             |      X      |             |
-| cinder     |      X      |             |             |
-| ceilometer |             |             |      X      |
-| aodh       |             |             |      X      |
-| gnocchi    |             |             |      X      |
-| heat       |             |             |      X      |
-| swift      |             |      X      |             |
-| sahara     |             |      X      |             |
-| trove      |             |      X      |             |
-| horizon    |      X      |             |             |
-| manila     |      X      |             |             |
-| nagios     |      X      |             |             |
-| SSL        |      X      |             |             |
-
-To run these tests:
-
-    export SCENARIO="scenario001"
-    ./run_tests.sh
-
-run_tests.sh will take care of installing the required dependencies,
-configure packstack to run according to the above matrix and run the complete
-installation process. If the installation is successful, tempest will also
-run smoke tests.
-
-By default, run_tests.sh will set up delorean (RDO Trunk) repositories.
-There are two ways of overriding default repositories:
-
-    export DELOREAN="http://someotherdomain.tld/delorean.repo"
-    export DELOREAN_DEPS="http://someotherdomain.tld/delorean-deps.repo"
-    ./run_tests.sh
-
-You can also choose to disable repository management entirely:
-
-    <setup your own custom repositories here>
-    export MANAGE_REPOS="false"
-    ./run_tests.sh
+The software is provided "as is", without warranty of any kind from my side.
+All files in project are included as fetched from source and may have been
+changed in the way to make things work with technologies specified above.
+Please read original license which is added to the project if you want to
+further use this software or modify it. All respective rights reserved to
+authors and contributors.

--- a/README_ORIGINAL
+++ b/README_ORIGINAL
@@ -1,0 +1,229 @@
+# Packstack
+
+Utility to install **OpenStack** on **Red Hat** based operating system. See
+other branches for older **OpenStack** versions. Details on how to
+contribute to **Packstack** may be found in the **Packstack** wiki at
+<https://wiki.openstack.org/wiki/Packstack> Additional information
+about involvement in the community around **Packstack** can be found at
+<https://openstack.redhat.com/Get_involved>
+
+
+This utility can be used to install **OpenStack** on a single or group of
+hosts (over `ssh`).
+
+This utility is still in the early stages, a lot of the configuration
+options have yet to be added.
+
+## Installation of packstack:
+
+    $ yum install -y git
+    $ git clone git://github.com/openstack/packstack.git
+    $ cd packstack && sudo python setup.py install
+
+## Installation of openstack-puppet-modules (REQUIRED if running packstack from source):
+
+    $ export GEM_HOME=/tmp/somedir
+    $ gem install r10k
+    $ sudo /tmp/somedir/bin/r10k puppetfile install -v
+    $ sudo cp -r packstack/puppet/modules/packstack /usr/share/openstack-puppet/modules
+
+### Option 1 (all-in-one)
+
+    $ packstack --allinone
+
+This will install all **OpenStack** services on a single host without
+prompting for any configuration information.  This will generate an
+"answers" file (`packstack-answers-<date>-<time>.txt`) containing all
+the values used for the install.
+
+If you need to re-run packstack, you must use the `--answer-file`
+option in order for packstack to use the correct values for passwords
+and other authentication credentials:
+
+    $ packstack --answer-file packstack-answers-<date>-<time>.txt
+
+### Option 2 (using answer file)
+
+    $ packstack --gen-answer-file=ans.txt
+
+Then edit `ans.txt` as appropriate e.g.
+
+- set `CONFIG_SSH_KEY` to a public ssh key to be installed to remote machines
+- Edit the IP address to anywhere you want to install a piece of OpenStack on another server
+- Edit the 3 network interfaces to whatever makes sense in your setup
+
+you'll need to use a icehouse repository for example for RHEL
+
+    $ CONFIG_REPO=http://repos.fedorapeople.org/repos/openstack/openstack-icehouse/epel-6/
+
+    $ packstack --answer-file=ans.txt
+
+### Option 3 (prompts for configuration options)
+
+    $ packstack
+
+that's it, if everything went well you can now start using OpenStack
+
+    $ cd
+    $ . keystonerc_admin
+    $ nova list
+    $ swift list  # if you have installed swift
+
+## Config options
+
+- `CONFIG_NOVA_COMPUTE_HOSTS` :
+  * A comma separated list of ip addresses on which to install nova compute
+- `CONFIG_SWIFT_STORAGE_HOSTS` :
+  * A comma separated list of swift storage devices
+    * `1.1.1.1`: create a testing loopback device and use this for storage
+    * `1.1.1.1/sdb`: use `/dev/sdb` on `1.1.1.1` as a storage device
+
+## Logging
+
+The location of the log files and generated puppet manifests are in the
+`/var/tmp/packstack` directory under a directory named by the date in which
+**Packstack** was run and a random string (e.g. `/var/tmp/packstack/20131022-204316-Bf3Ek2`).
+Inside, we find a manifest directory and the `openstack-setup.log` file; puppet
+manifests and a log file for each one are found inside the manifest directory.
+
+## Debugging
+
+To make **Packstack** write more detailed information into the log file you can use the `-d` switch:
+
+    $ packstack -d --allinone
+
+## Developing
+
+**Warning:**
+this procedure installs **openstack-puppet-modules** containing code that has
+not been upstreamed and fully tested yet and as such will not be as robust as
+the other install procedures.  It is recommended to install from **RPM**
+instead.
+
+To ease development of **Packstack** and **openstack-puppet-modules**, it can be
+useful to install from *git* such that updates to the git repositories are
+immediately effective without reinstallation of packstack and
+**openstack-puppet-modules**.
+
+To do this, start with a minimal **Fedora 21** installation.  Then remove any
+relevant packages that might conflict:
+
+    $ yum -y erase openstack-{packstack*,puppet-modules}
+
+Disable **SELinux** by changing "`enforcing`" to "`permissive`" in
+`/etc/sysconfig/selinux`, then reboot to allow service changes to take effect
+and swap over networking.  Then install packages:
+
+    $ yum -y install git python-setuptools
+
+And install **RDO**:
+
+    $ yum -y install https://rdo.fedorapeople.org/rdo-release.rpm
+    $ yum -y update
+
+Now we get **openstack-puppet-modules**.  Because `python setup.py
+install_puppet_modules` from **Packstack** copies rather than linking, this is not
+entirely straightforward:
+
+    $ git clone https://github.com/redhat-openstack/openstack-puppet-modules
+    $ cd openstack-puppet-modules
+    $ git checkout master-patches
+    $ mkdir /usr/share/openstack-puppet
+    $ ln -sv /root/openstack-puppet-modules /usr/share/openstack-puppet/modules
+
+Then we get **Packstack**, and perform a similar dance:
+
+    $ yum install -y python-crypto python-devel libffi-devel openssl-devel gcc-c++
+    $ git clone https://github.com/openstack/packstack
+    $ cd packstack
+    $ python setup.py develop
+    $ cd /usr/share/openstack-puppet/modules
+    $ ln -sv /root/packstack/packstack/puppet/modules/packstack
+
+And we're done.  Changes to the contents of **Packstack** and
+**openstack-puppet-modules** repositories are picked up by the **Packstack**
+executable without further intervention, and **Packstack** is ready to install.
+
+## Puppet Style Guide
+
+**IMPORTANT** <https://docs.puppetlabs.com/guides/style_guide.html>
+
+Please, respect the Puppet Style Guide as much as possible !
+
+## Running local Puppet-lint tests
+
+It assumes that both `bundler` as well as `rubygems` (and `ruby`) are already
+installed on the system. If not, run this command:
+
+    $ sudo yum install rubygems rubygem-bundler ruby ruby-devel -y
+
+Go into the **Packstack** root directory.
+
+    $ cd packstack/
+
+A `Rakefile` contains all you need to run puppet-lint task automatically over
+all the puppet manifests included in the **Packstack** project.
+
+    $ ls -l packstack/puppet/templates/
+
+and
+
+    $ ls -l packstack/puppet/modules/
+
+The default puppet-lint pattern for `.pp` files is `**/*.pp`. So there is no
+need to go inside those directories to run puppet-lint !
+
+    $ mkdir vendor
+    $ export GEM_HOME=vendor
+    $ bundle install
+    $ bundle exec rake lint
+
+## Packstack integration tests
+
+Packstack is integration tested in the OpenStack gate and provides the means to
+reproduce these tests on your environment if you wish.
+
+This is the current matrix of available tests:
+
+|     -      | scenario001 | scenario002 | scenario003 |
+|:----------:|:-----------:|:-----------:|:------------:
+| keystone   |      X      |      X      |      X      |
+| glance     |    file     |    swift    |     file    |
+| nova       |      X      |      X      |      X      |
+| neutron    |      X      |      X      |      X      |
+| lbaasv2    |             |      X      |             |
+| cinder     |      X      |             |             |
+| ceilometer |             |             |      X      |
+| aodh       |             |             |      X      |
+| gnocchi    |             |             |      X      |
+| heat       |             |             |      X      |
+| swift      |             |      X      |             |
+| sahara     |             |      X      |             |
+| trove      |             |      X      |             |
+| horizon    |      X      |             |             |
+| manila     |      X      |             |             |
+| nagios     |      X      |             |             |
+| SSL        |      X      |             |             |
+
+To run these tests:
+
+    export SCENARIO="scenario001"
+    ./run_tests.sh
+
+run_tests.sh will take care of installing the required dependencies,
+configure packstack to run according to the above matrix and run the complete
+installation process. If the installation is successful, tempest will also
+run smoke tests.
+
+By default, run_tests.sh will set up delorean (RDO Trunk) repositories.
+There are two ways of overriding default repositories:
+
+    export DELOREAN="http://someotherdomain.tld/delorean.repo"
+    export DELOREAN_DEPS="http://someotherdomain.tld/delorean-deps.repo"
+    ./run_tests.sh
+
+You can also choose to disable repository management entirely:
+
+    <setup your own custom repositories here>
+    export MANAGE_REPOS="false"
+    ./run_tests.sh

--- a/packstack/puppet/modules/packstack/manifests/nova/sched/ironic.pp
+++ b/packstack/puppet/modules/packstack/manifests/nova/sched/ironic.pp
@@ -2,6 +2,6 @@ class packstack::nova::sched::ironic ()
 {
     nova_config {
       'DEFAULT/scheduler_host_manager':
-        value => 'nova.scheduler.ironic_host_manager.IronicHostManager';
+        value => 'ironic_host_manager';
     }
 }

--- a/run_setup.sh
+++ b/run_setup.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Title:		run_setup.sh
+# Description:	Installation script for Packstack on CentOS 7 - OpenStack Newton release
+# Author:		jodlajodla
+# Date:			20170221
+# Version:		0.1
+# Usage:		bash run_setup.sh    OR    bash run_setup.sh ironic
+# Notes:		Script is intended to install either default Packstack components or Packstack with Ironic
+
+
+# Initial script variables
+if [ $(id -u) != 0 ]; then
+	SUDO='sudo -E'
+fi
+INCLUDE_IRONIC=$([[ "$1" == 'ironic' ]]; echo $?)
+
+# Script functions
+function change_puppetfile {
+	if [ -z $1 ]; then
+		# Change before install
+		mv Puppetfile Puppetfile.default
+		mv Puppetfile.ironic Puppetfile
+	else
+		# Change after install
+		mv Puppetfile Puppetfile.ironic
+		mv Puppetfile.default Puppetfile
+	fi
+}
+
+# Disable firewalld and NetworkManager
+$SUDO systemctl disable firewalld
+$SUDO systemctl stop firewalld
+$SUDO systemctl disable NetworkManager
+$SUDO systemctl stop NetworkManager
+$SUDO systemctl enable network
+$SUDO systemctl start network
+
+# Install Packstack packages
+$SUDO yum install -y centos-release-openstack-newton
+$SUDO yum update -y
+$SUDO yum install -y openstack-packstack
+
+# Check which type of installation was chosen and do workaround with Puppetfile in case of Ironic
+if [ INCLUDE_IRONIC -eq 1 ]; then
+	change_puppetfile
+fi
+
+# Install gem and Puppet modules
+$SUDO yum install -y gem
+export GEM_HOME=/tmp/gem_packstack
+gem install r10k
+$SUDO "$GEM_HOME/bin/r10k" puppet install -v
+$SUDO cp -r packstack/puppet/modules/packstack /usr/share/openstack-puppet/modules
+
+# Check which type of installation was chosen and do workaround with Puppetfile in case of Ironic
+if [ INCLUDE_IRONIC -eq 1 ]; then
+	packstack --os-ironic-install=y --nagios-install=n --allinone
+	change_puppetfile 1
+else
+	packstack --nagios-install=n --allinone
+fi
+
+exit 0


### PR DESCRIPTION
The only file that was fixed is `packstack/puppet/modules/packstack/manifests/nova/sched/ironic.pp`, other files are only an entry point for forked repo or helper scripts for installation.

When installing Packstack with Ironic on CentOS 7, OpenStack Newton release, there is an error with starting Nova Compute after install from official (CentOS) repository, because scheduler host manager has wrong value. Fix is to set this value to `ironic_host_manager`.